### PR TITLE
Fix zeromq message, from a serialized java string to string

### DIFF
--- a/src/main/java/org/edgexfoundry/messaging/impl/ZeroMQEventPublisherImpl.java
+++ b/src/main/java/org/edgexfoundry/messaging/impl/ZeroMQEventPublisherImpl.java
@@ -21,8 +21,7 @@ package org.edgexfoundry.messaging.impl;
 import com.google.gson.Gson;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
+import java.io.DataOutputStream;
 
 import org.edgexfoundry.domain.core.Event;
 import org.edgexfoundry.messaging.EventPublisher;
@@ -92,10 +91,10 @@ public class ZeroMQEventPublisherImpl implements EventPublisher {
    */
   private byte[] toByteArray(Event event) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    try (ObjectOutput out = new ObjectOutputStream(bos)) {
+    try (DataOutputStream out = new DataOutputStream(bos)) {
       Gson gson = new Gson();
       String eventString = gson.toJson(event);
-      out.writeObject(eventString);
+      out.write(eventString.getBytes());
       return bos.toByteArray();
     }
   }


### PR DESCRIPTION
After this change export-distro continue not working with the following message:

[2017-11-22 03:11:38.029] boot - 7080  INFO [main] --- ZeroMQEventSubscriber: Event entering export with id:  5a155b6ae4b0e3fa5e1158a3
[2017-11-22 03:11:38.039] boot - 7080 ERROR [main] --- ClientMessageSplitter: problem splitting messages per client request:  No enum constant org.edgexfoundry.domain.common.HTTPMethod.
